### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install global packages:
 #### Linux
 
 ```bash
-$ sudo apt-get install libssl-dev swig -y
+$ sudo apt-get install libssl-dev swig python-setuptools python2-dev -y
 ```
 
 #### OSX


### PR DESCRIPTION
Hi

I got errors if don't install this dependences:
```
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /usr/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-WEnj4B/m2crypto/setup.py'"'"'; __file__='"'"'/tmp/pip-install-WEnj4B/m2crypto/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-g6_Nsx/install-record.txt --single-version-externally-managed --user --prefix= --compile --install-headers /home/anboo/.local/include/python2.7/m2crypto Check the logs for full command output
```

```
  Using cached M2Crypto-0.37.1.tar.gz (1.2 MB)
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-OLHlOP/m2crypto/setup.py'"'"'; __file__='"'"'/tmp/pip-install-OLHlOP/m2crypto/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-LDYoRR
         cwd: /tmp/pip-install-OLHlOP/m2crypto/
    Complete output (3 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ImportError: No module named setuptools
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```