### PR TITLE
Remove unnecessary dependency & decompile the entire APK

### DIFF
--- a/apkleaks/apkleaks.py
+++ b/apkleaks/apkleaks.py
@@ -84,14 +84,7 @@ class APKLeaks:
 
 	def decompile(self):
 		self.writeln("** Decompiling APK...", clr.OKBLUE)
-		with ZipFile(self.file) as zipped:
-			try:
-				dex = self.tempdir + "/" + self.apk.package + ".dex"
-				with open(dex, "wb") as classes:
-					classes.write(zipped.read("classes.dex"))
-			except Exception as e:
-				sys.exit(self.writeln(str(e), clr.WARNING))
-		args = [self.jadx, dex, "-d", self.tempdir, "--deobf"]
+		args = [self.jadx, self.file, "-d", self.tempdir, "--deobf"]
 		comm = "%s" % (" ".join(quote(arg) for arg in args))
 		os.system(comm)
 
@@ -101,13 +94,14 @@ class APKLeaks:
 		for path, _, files in os.walk(path):
 			for fn in files:
 				filepath = os.path.join(path, fn)
-				if mimetypes.guess_type(filepath)[0] is None:
-					continue
 				with open(filepath) as handle:
-					for lineno, line in enumerate(handle):
-						mo = matcher.search(line)
-						if mo:
-							found.append(mo.group())
+					try:
+						for line in handle.readlines():
+							mo = matcher.search(line)
+							if mo:
+								found.append(mo.group())
+					except Exception:
+						pass
 		return list(set(found))
 
 	def extract(self, name, matches):

--- a/apkleaks/apkleaks.py
+++ b/apkleaks/apkleaks.py
@@ -10,7 +10,6 @@ import io
 import json
 import logging.config
 import mimetypes
-import numpy
 import os
 import re
 import shutil
@@ -96,10 +95,6 @@ class APKLeaks:
 		comm = "%s" % (" ".join(quote(arg) for arg in args))
 		os.system(comm)
 
-	def unique(self, list): 
-		x = numpy.array(list)
-		return (numpy.unique(x))
-
 	def finder(self, pattern, path):
 		matcher = re.compile(pattern)
 		found = []
@@ -113,7 +108,7 @@ class APKLeaks:
 						mo = matcher.search(line)
 						if mo:
 							found.append(mo.group())
-		return self.unique(found)
+		return list(set(found))
 
 	def extract(self, name, matches):
 		if len(matches):
@@ -127,7 +122,7 @@ class APKLeaks:
 				print(stdout)
 				self.fileout.write("%s" % (stdout + "\n" if self.json == False else ""))
 			self.fileout.write("%s" % ("\n" if self.json == False else ""))
-			self.outJSON["results"].append({"name": name, "matches": matches.tolist()})
+			self.outJSON["results"].append({"name": name, "matches": matches})
 			self.scanned = True
 
 	def scanning(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-numpy>=1.20.1
 pyaxmlparser>=0.3.24


### PR DESCRIPTION
- I have removed `numpy` as its use was limited to remove duplicates in findings list, using `list(set(findings))` does the work well.
- I have changed the arguments passed to `jadx` in order to decompile the entire APK. That way, the extraction of the leaks occurs on the entire content of the APK and obviously finds more things :]. (close #30)