### PR TITLE
fix docker run command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ apkleaks -f ~/path/to/file.apk
 # from Source
 $ python3 apkleaks.py -f ~/path/to/file.apk
 # or with Docker
-$ docker run -it --rm -v /tmp:/tmp apkleaks:latest -f /tmp/file.apk
+$ docker run -it --rm -v /tmp:/tmp dwisiswant0/apkleaks:latest -f /tmp/file.apk
 ```
 
 ## Options


### PR DESCRIPTION
currently the `docker run` command in the readme will produce the following error:

```
Unable to find image 'apkleaks:latest' locally
docker: Error response from daemon: pull access denied for apkleaks, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```

this is due to omitting the username prefix. I've updated the readme to include the correct command.