### PR TITLE
added --dir option to skip decompile and only scan the folder

### DIFF
--- a/apkleaks/apkleaks.py
+++ b/apkleaks/apkleaks.py
@@ -27,6 +27,7 @@ class APKLeaks:
 		self.file = os.path.realpath(args.file)
 		self.json = args.json
 		self.disarg = args.args
+		self.apk_dir = args.dir
 		self.prefix = "apkleaks-"
 		self.tempdir = tempfile.mkdtemp(prefix=self.prefix)
 		self.main_dir = os.path.dirname(os.path.realpath(__file__))
@@ -53,7 +54,7 @@ class APKLeaks:
 			sys.exit()
 
 	def integrity(self):
-		if os.path.exists(self.jadx) is False:
+		if os.path.exists(self.jadx) is False and self.apk_dir == None:
 			util.writeln("Can't find jadx binary.", col.WARNING)
 			valid = {"yes": True, "y": True, "ye": True, "no": False, "n": False}
 			while True:
@@ -117,6 +118,8 @@ class APKLeaks:
 	def scanning(self):
 		if self.apk is None:
 			sys.exit(util.writeln("** Undefined package. Exit!", col.FAIL))
+		if self.apk_dir :
+			self.tempdir = os.path.abspath(self.apk_dir)
 		util.writeln("\n** Scanning against '%s'" % (self.apk.package), col.OKBLUE)
 		self.out_json["package"] = self.apk.package
 		self.out_json["results"] = []

--- a/apkleaks/cli.py
+++ b/apkleaks/cli.py
@@ -19,6 +19,7 @@ def header():
 def argument():
 	parser = argparse.ArgumentParser()
 	parser.add_argument("-f", "--file", help="APK file to scanning", type=str, required=True)
+	parser.add_argument("-d", "--dir", help="Directory of decompiled apk to scan", type=str, required=False)
 	parser.add_argument("-o", "--output", help="Write to file results (random if not set)", type=str, required=False)
 	parser.add_argument("-p", "--pattern", help="Path to custom patterns JSON", type=str, required=False)
 	parser.add_argument("-a", "--args", help="Disassembler arguments (e.g. --threads-count 5 --deobf)", type=str, required=False)
@@ -32,7 +33,8 @@ def main():
 	init = APKLeaks(args)
 	try:
 		init.integrity()
-		init.decompile()
+		if not args.dir :
+			init.decompile()
 		init.scanning()
 	finally:
 		init.cleanup()


### PR DESCRIPTION
Related to #15 

Sometimes you already decompiled using another tool or had to change some configs to make it work.
With this option you just need to pass the folder