### PR TITLE
support python3.12

### DIFF
--- a/apkleaks/apkleaks.py
+++ b/apkleaks/apkleaks.py
@@ -10,7 +10,7 @@ import tempfile
 import threading
 
 from contextlib import closing
-from distutils.spawn import find_executable
+from shutil import which
 from pathlib import Path
 from pipes import quote
 from urllib.request import urlopen
@@ -33,7 +33,7 @@ class APKLeaks:
 		self.output = tempfile.mkstemp(suffix=".%s" % ("json" if self.json else "txt"), prefix=self.prefix)[1] if args.output is None else args.output
 		self.fileout = open(self.output, "%s" % ("w" if self.json else "a"))
 		self.pattern = os.path.join(str(Path(self.main_dir).parent), "config", "regexes.json") if args.pattern is None else args.pattern
-		self.jadx = find_executable("jadx") if find_executable("jadx") is not None else os.path.join(str(Path(self.main_dir).parent), "jadx", "bin", "jadx%s" % (".bat" if os.name == "nt" else "")).replace("\\","/")
+		self.jadx = which("jadx") if which("jadx") is not None else os.path.join(str(Path(self.main_dir).parent), "jadx", "bin", "jadx%s" % (".bat" if os.name == "nt" else "")).replace("\\","/")
 		self.out_json = {}
 		self.scanned = False
 		logging.config.dictConfig({"version": 1, "disable_existing_loggers": True})

--- a/apkleaks/cli.py
+++ b/apkleaks/cli.py
@@ -4,16 +4,19 @@ import os
 import sys
 from pathlib import Path
 
-import pkg_resources
-
 from apkleaks.apkleaks import APKLeaks
 from apkleaks.colors import color as col
 
 def header():
 	try:
-		VERSION = "v" + pkg_resources.require("apkleaks")[0].version
-	except Exception:
-		VERSION = open(os.path.join(str(Path(__file__).parent.parent), "VERSION"), "r").read().strip()
+		from importlib import metadata
+		VERSION = "v" + metadata.version("apkleaks")
+	except ImportError:
+		try:
+			import pkg_resources
+			VERSION = "v" + pkg_resources.require("apkleaks")[0].version
+		except Exception:
+			VERSION = open(os.path.join(str(Path(__file__).parent.parent), "VERSION"), "r").read().strip()
 	print(col.HEADER + "     _    ____  _  ___               _        \n    / \\  |  _ \\| |/ / |    ___  __ _| | _____ \n   / _ \\ | |_) | ' /| |   / _ \\/ _` | |/ / __|\n  / ___ \\|  __/| . \\| |__|  __/ (_| |   <\\__ \\\n /_/   \\_\\_|   |_|\\_\\_____\\___|\\__,_|_|\\_\\___/\n {}\n --\n Scanning APK file for URIs, endpoints & secrets\n (c) 2020-2021, dwisiswant0\n".format(VERSION) + col.ENDC, file=sys.stderr)
 
 def argument():


### PR DESCRIPTION
Python 3.12 has removed `distutils` and its bundled `setuptools` (aka `pkg_resources`): https://docs.python.org/3.12/whatsnew/3.12.html#removed
