### PR TITLE
Added Java & jadx to Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,17 @@ LABEL description="Scanning APK file for URIs, endpoints & secrets."
 LABEL repository="https://github.com/dwisiswant0/apkleaks"
 LABEL maintainer="dwisiswant0"
 
+RUN apt-get update && \
+    apt-get install -y openjdk-17-jre-headless && \
+    apt-get install -y unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Instal jadx 1.2.0
+ADD https://github.com/skylot/jadx/releases/download/v1.2.0/jadx-1.2.0.zip /tmp/jadx.zip
+RUN unzip /tmp/jadx.zip -d /opt/jadx && \
+    rm /tmp/jadx.zip && \
+    ln -s /opt/jadx/bin/jadx /usr/local/bin/jadx
+
 WORKDIR /app
 
 COPY requirements.txt .


### PR DESCRIPTION
Closes #96

I personally like to use dockerized apps by setting aliases, example:

```bash
alias apkleaks='docker run -it --rm -v "$(pwd)":/app dwisiswant0/apkleaks:latest'
```
This allows to use `apkleaks` like an installed binary, note also that it's binding the current_dir to the container.
